### PR TITLE
Emitting output of commands running solo in real time & printing 'still-running' spinner for long-running commands

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -33,6 +33,7 @@
 #include "dynout_parser.h"
 #include "graph.h"
 #include "metrics.h"
+#include "msvc_helper.h"
 #include "state.h"
 #include "status.h"
 #include "subprocess.h"
@@ -454,6 +455,7 @@ struct RealCommandRunner : public CommandRunner {
   virtual bool CanRunMore() const;
   virtual bool StartCommand(Edge* edge);
   virtual bool WaitForCommand(Result* result);
+  virtual void PeekCommandOutput(Edge* edge, string* out);
   virtual vector<Edge*> GetActiveEdges();
   virtual void Abort();
 
@@ -482,6 +484,16 @@ bool RealCommandRunner::CanRunMore() const {
         || GetLoadAverage() < config_.max_load_average);
 }
 
+void RealCommandRunner::PeekCommandOutput(Edge* edge, string* out)
+{
+  // Note: search linearly, but as long this is only invoked when number of
+  // edges == 1, nothing better is necessary.
+  for (map<const Subprocess*, Edge*>::iterator i = subproc_to_edge_.begin();
+       i != subproc_to_edge_.end(); ++i)
+    if (i->second == edge)
+      *out = i->first->GetOutput();
+}
+
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
   Subprocess* subproc = subprocs_.Add(command, edge->use_console());
@@ -498,6 +510,9 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
     bool interrupted = subprocs_.DoWork();
     if (interrupted)
       return false;
+
+    result->status = ExitTimeout;
+    return true;
   }
 
   result->status = subproc->Finish();
@@ -661,6 +676,11 @@ bool Builder::Build(string* err) {
         status_->BuildFinished();
         *err = "interrupted by user";
         return false;
+      }
+
+      if (result.status == ExitTimeout) {
+        ReportProgress();
+        continue;
       }
 
       --pending_commands;
@@ -883,6 +903,28 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
     }
   }
   return true;
+}
+
+void Builder::ReportProgress(void)
+{
+  vector<Edge*> active_edges = command_runner_->GetActiveEdges();
+  if (active_edges.size() < 1)
+    return;
+
+  Edge* edge = active_edges[0];
+  if (active_edges.size() == 1 && !plan_.HasWork()) {
+    // If a command is running 'solo' AND produces some output, start printing
+    // its output in the real time w/o waiting for its completion.
+    string output;
+    command_runner_->PeekCommandOutput(edge, &output);
+    if (output.size()) {
+      ((StatusPrinter*)status_)->BuildEdgeRunningSolo(edge, output);
+      return;
+    }
+  }
+
+  //Call this only if it is needed to have feedback that a long command is under execution
+  //((StatusPrinter*)status_)->BuildEdgeStillRunning(edge);
 }
 
 bool Builder::ExtractDeps(CommandRunner::Result* result,

--- a/src/build.h
+++ b/src/build.h
@@ -26,6 +26,8 @@
 #include "graph.h"  // XXX needed for DependencyScan; should rearrange.
 #include "exit_status.h"
 #include "util.h"  // int64_t
+#include "line_printer.h"
+#include "metrics.h"
 
 struct BuildLog;
 struct Builder;
@@ -34,6 +36,9 @@ struct Edge;
 struct Node;
 struct State;
 struct Status;
+
+const uint64_t kStillRunningDelayMsec = 3000;
+const int kStillRunningFPS = 4;
 
 /// Plan stores the state of a build plan: what we intend to build,
 /// which steps we're ready to execute.
@@ -48,6 +53,9 @@ struct Plan {
   // Pop a ready edge off the queue of edges to build.
   // Returns NULL if there's no work to do.
   Edge* FindWork();
+
+  // Returns true if there are edges waiting to run now.
+  bool HasWork() const { return !ready_.empty(); }
 
   /// Returns true if there's more work to be done.
   bool more_to_do() const { return wanted_edges_ > 0 && command_edges_ > 0; }
@@ -149,6 +157,9 @@ struct CommandRunner {
   /// Wait for a command to complete, or return false if interrupted.
   virtual bool WaitForCommand(Result* result) = 0;
 
+  /// Return command output collected so far
+  virtual void PeekCommandOutput(Edge* edge, std::string* out) {}
+
   virtual std::vector<Edge*> GetActiveEdges() { return std::vector<Edge*>(); }
   virtual void Abort() {}
 };
@@ -203,6 +214,8 @@ struct Builder {
   /// Update status ninja logs following a command termination.
   /// @return false if the build can not proceed further due to a fatal error.
   bool FinishCommand(CommandRunner::Result* result, std::string* err);
+
+  void ReportProgress(void);
 
   /// Used for tests.
   void SetBuildLog(BuildLog* log) {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2246,12 +2246,12 @@ TEST_F(BuildTest, StatusFormatElapsed) {
   status_.BuildStarted();
   // Before any task is done, the elapsed time must be zero.
   EXPECT_EQ("[%/e0.000]",
-            status_.FormatProgressStatus("[%%/e%e]", 0));
+            status_.FormatProgressStatus("[%%/e%e]"));
 }
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0));
+            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]"));
 }
 
 TEST_F(BuildTest, FailedDepsParse) {

--- a/src/exit_status.h
+++ b/src/exit_status.h
@@ -18,7 +18,8 @@
 enum ExitStatus {
   ExitSuccess,
   ExitFailure,
-  ExitInterrupted
+  ExitInterrupted,
+  ExitTimeout
 };
 
 #endif  // NINJA_EXIT_STATUS_H_

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -768,7 +768,7 @@ bool ImplicitDepLoader::LoadOutputsFromLog(Edge* edge, string* err) {
   vector<Node*> implicit_outputs;
   implicit_outputs.reserve(deps->outputs_count);
 
-  for (size_t i = deps->node_count - deps->outputs_count; i < deps->node_count; i++) {
+  for (int i = deps->node_count - deps->outputs_count; i < deps->node_count; i++) {
     bool exist = false;
     Node* new_node = deps->nodes[i];
     for (vector<Node*>::iterator n = edge->outputs_.begin();

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -164,3 +164,11 @@ void LinePrinter::SetConsoleLocked(bool locked) {
     line_buffer_.clear();
   }
 }
+
+void LinePrinter::PrintRaw(const string& to_print) {
+  if (to_print.empty())
+    return;
+  fwrite(to_print.c_str(), to_print.size(), 1, stdout);
+  fflush(stdout);
+  have_blank_line_ =  (*to_print.rbegin() == '\n');
+}

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -39,6 +39,10 @@ struct LinePrinter {
   /// Prints a string on a new line, not overprinting previous output.
   void PrintOnNewLine(const std::string& to_print);
 
+  /// Prints the string at current cursor position as-is, not overprinting
+  /// previous output and flushes the stdout.
+  void PrintRaw(const std::string& to_print);
+
   /// Lock or unlock the console.  Any output sent to the LinePrinter while the
   /// console is locked will not be printed until it is unlocked.
   void SetConsoleLocked(bool locked);

--- a/src/status_test.cc
+++ b/src/status_test.cc
@@ -23,7 +23,7 @@ TEST(StatusTest, StatusFormatElapsed) {
   status.BuildStarted();
   // Before any task is done, the elapsed time must be zero.
   EXPECT_EQ("[%/e0.000]",
-            status.FormatProgressStatus("[%%/e%e]", 0));
+            status.FormatProgressStatus("[%%/e%e]"));
 }
 
 TEST(StatusTest, StatusFormatReplacePlaceholder) {
@@ -31,5 +31,5 @@ TEST(StatusTest, StatusFormatReplacePlaceholder) {
   StatusPrinter status(config);
 
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0));
+            status.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]"));
 }

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -110,4 +110,9 @@ struct SubprocessSet {
 #endif
 };
 
+/// SubprocessSet::DoWork() may return on a timeout
+///  after waiting for kPollTimeoutNano ns, allowing
+///  ninja to update progress of long-running tasks.
+const long kPollTimeoutNano = 1000000000L/20; // = 20Hz
+
 #endif // NINJA_SUBPROCESS_H_

--- a/src/version.cc
+++ b/src/version.cc
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-const char* kNinjaVersion = "1.11.1.conti.1";
+const char* kNinjaVersion = "1.11.1.conti.2";
 
 void ParseVersion(const string& version, int* major, int* minor) {
   size_t end = version.find('.');


### PR DESCRIPTION
Emitting output of commands running solo in real time
Printing 'still-running' spinner for long-running commands